### PR TITLE
removing ember-meta from dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2912,6 +2912,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/broccoli-file-creator/-/broccoli-file-creator-1.2.0.tgz",
       "integrity": "sha512-l9zthHg6bAtnOfRr/ieZ1srRQEsufMZID7xGYRW3aBDv3u/3Eux+Iawl10tAGYE5pL9YB4n5X4vxkp6iNOoZ9g==",
+      "dev": true,
       "requires": {
         "broccoli-plugin": "^1.1.0",
         "mkdirp": "^0.5.1"
@@ -6117,6 +6118,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/ember-cli-head/-/ember-cli-head-0.4.1.tgz",
       "integrity": "sha512-MIgshw5nGil7Q/TU4SDRCsgsiA3wPC9WqOig/g1LlHTNXjR4vH7s/ddG7GTfK5Kt4ZQHJEUDXpd/lIbdBkIQ/Q==",
+      "dev": true,
       "requires": {
         "ember-cli-babel": "^6.11.0",
         "ember-cli-htmlbars": "^2.0.3"
@@ -6824,6 +6826,7 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/ember-get-config/-/ember-get-config-0.2.4.tgz",
       "integrity": "sha1-EYSSoqA9c+RgBO13eSiUICH+Hs0=",
+      "dev": true,
       "requires": {
         "broccoli-file-creator": "^1.1.1",
         "ember-cli-babel": "^6.3.0"
@@ -6961,17 +6964,6 @@
       "integrity": "sha512-cAiG6N9HwvoPsMIePgwECilPrKRrIdfKqx9g8qWHKPS4vwrgS2PTeLmOcJvVYbBTXkHaFZmecDRpf6xAj6zk7A==",
       "requires": {
         "ember-cli-babel": "^6.11.0"
-      }
-    },
-    "ember-meta": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ember-meta/-/ember-meta-0.1.3.tgz",
-      "integrity": "sha512-4d4OH6PZongXgD8xu4YDAjHdqKK67xRvxYeE5ZqzQxEe25RtFXVkVIoRgEWFSXKIitZ/jbp8eD2XAAwyohNlvw==",
-      "requires": {
-        "ember-cli-babel": "^6.6.0",
-        "ember-cli-head": "^0.4.0",
-        "ember-get-config": "^0.2.4",
-        "ember-truth-helpers": "^2.0.0"
       }
     },
     "ember-moment": {

--- a/package.json
+++ b/package.json
@@ -31,13 +31,11 @@
     "debug": "^3.1.0",
     "downsize-cjs": "^0.1.1",
     "ember-cli-babel": "^6.6.0",
-    "ember-cli-head": "^0.4.0",
     "ember-cli-htmlbars": "^2.0.1",
     "ember-cli-sass": "^8.0.1",
     "ember-cli-string-helpers": "^1.8.0",
     "ember-composable-helpers": "^2.0.3",
     "ember-lodash": "^4.18.0",
-    "ember-meta": "^0.1.3",
     "ember-styleguide": "^2.4.0",
     "ember-truth-helpers": "^2.0.0",
     "sass": "^1.14.3"


### PR DESCRIPTION
This will allow the ember-meta configuration from empress-blog to take over and do things correctly 👍 