### PR TITLE
Remove space around commas for multi-author lists

### DIFF
--- a/addon/components/author-list.hbs
+++ b/addon/components/author-list.hbs
@@ -1,7 +1,7 @@
 By
-{{#each @post.authors as |author index|}}
+{{#each @post.authors as |author index|~}}
   {{if index ','}}
   <LinkTo @route="author" @model={{author.id}} class="blog-post-author">
-    {{author.name}}
+    {{~author.name~}}
   </LinkTo>
-{{/each}}
+{{~/each}}


### PR DESCRIPTION
Fixes #6 using http://handlebarsjs.com/guide/expressions.html#whitespace-control

Before:

<img width="438" alt="image" src="https://user-images.githubusercontent.com/643885/80378353-278dd300-8862-11ea-8fdb-cbd9f8c63296.png">

After:

<img width="412" alt="image" src="https://user-images.githubusercontent.com/643885/80378329-1d6bd480-8862-11ea-8de8-8f3b4bba1d17.png">
