### PR TITLE
Replace some custom `TagPostList` styles with Ember Styleguide

### DIFF
--- a/addon/components/tag-post-list.hbs
+++ b/addon/components/tag-post-list.hbs
@@ -1,4 +1,4 @@
-<div class="tag-post-list">
+<div class="tag-post-list bg-none">
   <h3
     id={{this.titleId}}
     class="text-lg tag-post-list-title"
@@ -15,7 +15,6 @@
     {{#each this.topPosts key="id" as |post|}}
       <li class="my-1">
         <LinkTo
-          class="tag-post-list-link"
           data-test-post-link
           @route="post"
           @model={{post.id}}
@@ -28,7 +27,6 @@
 
   <div class="mt-1 ml-1">
     <LinkTo
-      class="tag-post-list-link"
       data-test-more-posts
       @route="tag"
       @model={{@tag.id}}

--- a/addon/styles/tag-post-list.css
+++ b/addon/styles/tag-post-list.css
@@ -1,8 +1,3 @@
 .tag-post-list .tag-post-list-title {
   color: var(--color-gray-600);
 }
-
-.tag-post-list .tag-post-list-link {
-  background: none;
-  text-decoration: none;
-}


### PR DESCRIPTION
The PR leverages Ember Styleguide for turning off link-underline styles (https://ember-styleguide.netlify.app/css/helpers).