### PR TITLE
fix percy changes because of floating date

### DIFF
--- a/app/templates/author.hbs
+++ b/app/templates/author.hbs
@@ -47,7 +47,7 @@
             {{#each (sort-by 'date:desc' @model.posts) as |post|}}
 
                 {{!-- The tag below includes the markup for each post - partials/post-card.hbs --}}
-                <PostCard @article={{post}} />
+                <PostCard @post={{post}} />
 
             {{/each}}
         </div>


### PR DESCRIPTION
This is just a tiny fix for Percy. We're passing the wrong argument to the `<PostCard />` component, which means that the date is null, and moment displays a null date as "now" 👍 