### PR TITLE
Fixing width to ensure that images are limited to container's width

### DIFF
--- a/addon/styles/sidebar.css
+++ b/addon/styles/sidebar.css
@@ -31,6 +31,10 @@
   background-color: var(--color-gray-100);
 }
 
+.sidebar-container img {
+  max-width: 100%;
+}
+
 @media (max-width: 768px) {
   .sidebar-container {
     display: block;

--- a/addon/styles/sidebar.css
+++ b/addon/styles/sidebar.css
@@ -13,18 +13,9 @@
   max-width: var(--container-width);
   margin: auto;
   display: grid;
-  grid-template-areas: "main" "nav";
   grid-template-columns: 1fr 234px;
   grid-gap: 32px;
   padding: var(--spacing-6) var(--grid-margin);
-}
-
-.sidebar-container > main {
-  grid-area: "main";
-}
-
-.sidebar-container > nav {
-  grid-area: "nav";
 }
 
 .bg-main {


### PR DESCRIPTION
Currently, the image overflows and makes the page horizontally scrollable

This change is being done to ensure that the image is not larger than the content width
<img width="1680" alt="Screenshot 2020-06-14 at 22 35 37" src="https://user-images.githubusercontent.com/12375430/84599820-83ec9680-ae92-11ea-944f-0d46f5152b24.png">


Changes have also been made to ensure consistency in width for all images on the page: 
<img width="1680" alt="Screenshot 2020-06-14 at 22 35 49" src="https://user-images.githubusercontent.com/12375430/84599839-a088ce80-ae92-11ea-8377-49642d1a0394.png">


And for responsive devices
<img width="706" alt="Screenshot 2020-06-14 at 22 46 18" src="https://user-images.githubusercontent.com/12375430/84599809-70413000-ae92-11ea-9609-c9596f7f697f.png">

fixes https://github.com/ember-learn/empress-blog-ember-template/issues/18