### PR TITLE
fix issue with ember-get-config and comments

### DIFF
--- a/addon/components/comments.js
+++ b/addon/components/comments.js
@@ -2,13 +2,13 @@ import Component from '@glimmer/component';
 import moment from 'moment';
 import { action } from '@ember/object';
 
-import { environment } from 'ember-get-config';
+import config from 'ember-get-config';
 
 export default class CommentsComponent extends Component {
   scriptElementRef = null;
 
   get showComments () {
-    return environment === 'production';
+    return config.environment === 'production';
   }
 
   get useDiscourse() {


### PR DESCRIPTION
I made the previous change to @nickschot's comment implementation without testing the getter function 🙈 essentially it's a simple mistake, you can't import and destructure on one line with `ember-get-config`, it just doesn't work that way. 

I noticed the issue when looking at the latest release on the ember-blog WIP branch 👍 