### PR TITLE
close sidebar after a route transition

### DIFF
--- a/addon/components/sidebar.js
+++ b/addon/components/sidebar.js
@@ -1,9 +1,24 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 export default class SidebarComponent extends Component {
+  @service router;
+
   @tracked isOpen = false;
+
+  constructor() {
+    super(...arguments);
+
+    this.router.on('routeDidChange', this.close);
+  }
+
+  willDestroy() {
+    this.router.off('routeDidChange', this.close);
+
+    super.willDestroy(...arguments);
+  }
 
   @action
   toggle() {
@@ -12,6 +27,8 @@ export default class SidebarComponent extends Component {
 
   @action
   close() {
-    this.isOpen = false;
+    if (this.isOpen) {
+      this.isOpen = false;
+    }
   }
 }


### PR DESCRIPTION
This is the least invasive implementation which works without modification of the content. The only case where it doesn't close is if you click on a link which matches the current page.