### PR TITLE
hide the loading button for a single render so Chrome does not keep the scroll position at the loading button

### DIFF
--- a/addon/components/load-posts.hbs
+++ b/addon/components/load-posts.hbs
@@ -6,7 +6,7 @@
   {{else if this.visiblePosts.length}}
     {{yield this.visiblePosts}}
 
-    {{#if (gt this.totalPosts this.postAmount)}}
+    {{#if this.showLoadMoreButton}}
       <div class="text-center">
         <button type="button" class="es-button" {{on "click" this.loadMore}}>Load more</button>
       </div>


### PR DESCRIPTION
fixes #71 