### PR TITLE
replace last moment usages & remove moment dependency

### DIFF
--- a/addon/components/comments.hbs
+++ b/addon/components/comments.hbs
@@ -14,7 +14,7 @@
   {{else}}
   <ul class="list-unstyled layout">
     <EsCard>
-      Comments Disabled in Developmenet and Test mode
+      Comments Disabled in Development and Test mode
     </EsCard>
   </ul>
   {{/if}}

--- a/addon/components/comments.js
+++ b/addon/components/comments.js
@@ -1,5 +1,4 @@
 import Component from '@glimmer/component';
-import moment from 'moment';
 import { action } from '@ember/object';
 
 import config from 'ember-get-config';
@@ -12,11 +11,11 @@ export default class CommentsComponent extends Component {
   }
 
   get useDiscourse() {
-    return moment('2019-01-01').isBefore(this.args.post.date);
+    return new Date('2019-01-01') < this.args.post.date;
   }
 
   get oldStylePostUrl() {
-    const dateUrl = moment(this.args.post.date).format('YYYY/MM/DD');
+    const dateUrl = this.args.post.date.toISOString().split('T')[0].replace(/-/g, '/');
     return `https://emberjs.com/blog/${dateUrl}/${this.args.post.id}.html`
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,8 +21,7 @@
         "ember-showdown-prism": "^2.2.0",
         "ember-styleguide": "^5.1.0",
         "ember-svg-jar": "^2.2.3",
-        "ember-test-waiters": "^2.1.3",
-        "moment": "^2.27.0"
+        "ember-test-waiters": "^2.1.3"
       },
       "devDependencies": {
         "@ember/optional-features": "^1.3.0",
@@ -24568,14 +24567,6 @@
       "integrity": "sha1-bQUVYRyKjITkhKogABKbmOmB/ws=",
       "engines": {
         "node": ">0.9"
-      }
-    },
-    "node_modules/moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/morgan": {
@@ -53317,11 +53308,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.4.0.tgz",
       "integrity": "sha1-bQUVYRyKjITkhKogABKbmOmB/ws="
-    },
-    "moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "morgan": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -43,8 +43,7 @@
     "ember-showdown-prism": "^2.2.0",
     "ember-styleguide": "^5.1.0",
     "ember-svg-jar": "^2.2.3",
-    "ember-test-waiters": "^2.1.3",
-    "moment": "^2.27.0"
+    "ember-test-waiters": "^2.1.3"
   },
   "devDependencies": {
     "@ember/optional-features": "^1.3.0",


### PR DESCRIPTION
# a moment like this
[![a moment like this](https://img.youtube.com/vi/sxbX-z5-QHs/0.jpg)](https://www.youtube.com/watch?v=sxbX-z5-QHs)


---

Replaces the last 2 usages of moment with native alternatives & removes the moment dependency itself.
