### PR TITLE
update empress-blog to v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "ember-template-lint": "^2.9.1",
         "ember-test-selectors": "^4.1.0",
         "ember-try": "^1.4.0",
-        "empress-blog": "^2.3.1",
+        "empress-blog": "^3.0.1",
         "eslint": "^7.5.0",
         "eslint-plugin-ember": "^8.9.1",
         "eslint-plugin-node": "^11.1.0",
@@ -16412,6 +16412,20 @@
         "node": "8.* || 10.* || >= 12"
       }
     },
+    "node_modules/ember-scroll": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ember-scroll/-/ember-scroll-1.0.2.tgz",
+      "integrity": "sha512-/jfB/CgPE2wmoJZwDIoQSATdy/tuTddejDVGoEisgLcdUkA8vdKYrcKkwifpUSKlkLWJfrtD9J9oWylAp5CfnQ==",
+      "dev": true,
+      "dependencies": {
+        "ember-cli-babel": "^7.21.0",
+        "ember-cli-htmlbars": "^5.2.0",
+        "ember-decorators-polyfill": "^1.1.5"
+      },
+      "engines": {
+        "node": "10.* || >= 12"
+      }
+    },
     "node_modules/ember-showdown-prism": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ember-showdown-prism/-/ember-showdown-prism-2.2.0.tgz",
@@ -18661,9 +18675,9 @@
       }
     },
     "node_modules/empress-blog": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/empress-blog/-/empress-blog-2.3.1.tgz",
-      "integrity": "sha512-6Vi2LbSS6Mb/x9lzIYNvhrhY63IVOE/BnRXmxp1ULGNCxPSsWjbVsX40r9y+mxcw04yQnkIw0jsG6Tzzjgr0tQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/empress-blog/-/empress-blog-3.0.1.tgz",
+      "integrity": "sha512-kuyUAYAs4tFo+QatRQfEgDBFa9WvTT8+vMgU9WfGs54qX+s7O+2O0XxcsXTaXqbINIhgJEYTE+Qd3wYDSXo0dg==",
       "dev": true,
       "dependencies": {
         "broccoli-funnel": "^3.0.3",
@@ -18682,6 +18696,7 @@
         "ember-decorators-polyfill": "^1.1.5",
         "ember-get-config": "^0.3.0",
         "ember-meta": "^1.0.0",
+        "ember-scroll": "^1.0.2",
         "empress-blueprint-helpers": "^1.2.1",
         "js-yaml": "^3.13.1",
         "lodash": "^4.17.20",
@@ -46584,6 +46599,17 @@
         "recast": "^0.18.1"
       }
     },
+    "ember-scroll": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ember-scroll/-/ember-scroll-1.0.2.tgz",
+      "integrity": "sha512-/jfB/CgPE2wmoJZwDIoQSATdy/tuTddejDVGoEisgLcdUkA8vdKYrcKkwifpUSKlkLWJfrtD9J9oWylAp5CfnQ==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.21.0",
+        "ember-cli-htmlbars": "^5.2.0",
+        "ember-decorators-polyfill": "^1.1.5"
+      }
+    },
     "ember-showdown-prism": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ember-showdown-prism/-/ember-showdown-prism-2.2.0.tgz",
@@ -48437,9 +48463,9 @@
       "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
     },
     "empress-blog": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/empress-blog/-/empress-blog-2.3.1.tgz",
-      "integrity": "sha512-6Vi2LbSS6Mb/x9lzIYNvhrhY63IVOE/BnRXmxp1ULGNCxPSsWjbVsX40r9y+mxcw04yQnkIw0jsG6Tzzjgr0tQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/empress-blog/-/empress-blog-3.0.1.tgz",
+      "integrity": "sha512-kuyUAYAs4tFo+QatRQfEgDBFa9WvTT8+vMgU9WfGs54qX+s7O+2O0XxcsXTaXqbINIhgJEYTE+Qd3wYDSXo0dg==",
       "dev": true,
       "requires": {
         "broccoli-funnel": "^3.0.3",
@@ -48458,6 +48484,7 @@
         "ember-decorators-polyfill": "^1.1.5",
         "ember-get-config": "^0.3.0",
         "ember-meta": "^1.0.0",
+        "ember-scroll": "^1.0.2",
         "empress-blueprint-helpers": "^1.2.1",
         "js-yaml": "^3.13.1",
         "lodash": "^4.17.20",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "ember-template-lint": "^2.9.1",
     "ember-test-selectors": "^4.1.0",
     "ember-try": "^1.4.0",
-    "empress-blog": "^2.3.1",
+    "empress-blog": "^3.0.1",
     "eslint": "^7.5.0",
     "eslint-plugin-ember": "^8.9.1",
     "eslint-plugin-node": "^11.1.0",


### PR DESCRIPTION
This brings the empress-blog version in line with the version used on the ember-blog. Only relevant while working on the template of course.