### PR TITLE
Replace ProgressBar with ember-styleguide components

### DIFF
--- a/addon/components/progress-bar.hbs
+++ b/addon/components/progress-bar.hbs
@@ -1,1 +1,0 @@
-<div class="progress-bar" aria-hidden style={{this.progress.style}} ...attributes></div>

--- a/addon/components/progress-bar.js
+++ b/addon/components/progress-bar.js
@@ -1,6 +1,0 @@
-import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
-
-export default class ProgressBarComponent extends Component {
-  @service progress;
-}

--- a/addon/styles/progress-bar.css
+++ b/addon/styles/progress-bar.css
@@ -1,8 +1,0 @@
-.progress-bar {
-  position: fixed;
-  left: 0;
-  top: 0;
-  height: 3px;
-  box-shadow: 0 0 10px rgba(0, 13, 41, 0.6);
-  background: var(--color-brand) !important;
-}

--- a/app/components/progress-bar.js
+++ b/app/components/progress-bar.js
@@ -1,2 +1,0 @@
-/* eslint-disable prettier/prettier */
-export { default } from 'empress-blog-ember-template/components/progress-bar';

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,6 +1,6 @@
 <HeadLayout />
 
-<ProgressBar/>
+<EsProgressBar/>
 
 <EsHeader />
 


### PR DESCRIPTION
This PR implements Issue #112 replacing the `<ProgressBar />` component with `<EsProgressBar />`. The `<Sidebar />` component was also replaced with `<EsSidebar />` as the upgrade to the latest version of `ember-styleguide` included some conflicting styles causing display issues.
