### PR TITLE
simplify github ci

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,166 +2,71 @@ name: CI
 
 on:
   push:
-    branches: [ $default-branch ]
-  pull_request:
+    branches:
+      - main
+      - master
+  pull_request: {}
+
+concurrency:
+   group: ci-${{ github.head_ref || github.ref }}
+   cancel-in-progress: true
 
 jobs:
-  tests:
+  test:
+    name: "Tests"
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [10.x]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: Cache Node.js modules
-      uses: actions/cache@v2
-      with:
-        path: ~/.npm
-        key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.OS }}-node-
-          ${{ runner.OS }}-
-    - run: npm i -g npm@7
-    - run: npm ci
-    - run: npm run lint
-    - run: npx percy exec -- npm run test:ember
-      env:
-        CI: true
-        PERCY_TOKEN: ce5e8d59a35851ea07032b21668a6718e8daf4ac8da2f4f3fdcafc8c89dd0a0f
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 10.x
+          cache: npm
+      - run: npm i -g npm@7
+      - run: npm ci
+      - run: npm run lint
+      - run: npx percy exec -- npm run test:ember
+        env:
+          CI: true
+          PERCY_TOKEN: ce5e8d59a35851ea07032b21668a6718e8daf4ac8da2f4f3fdcafc8c89dd0a0f
 
-  ember_floating_dependencies:
+  floating:
+    name: "Floating Dependencies"
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [10.x]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm i -g npm@7
-    - run: npm install --no-package-lock
-    - run: npm run test:ember
-      env:
-        CI: true
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 10.x
+          cache: npm
+      - run: npm i -g npm@7
+      - run: npm install --no-shrinkwrap
+      - run: npm run test:ember
 
-  ember_try_3_16:
+  try-scenarios:
+    name: ${{ matrix.try-scenario }}
     runs-on: ubuntu-latest
+    needs: 'test'
+
     strategy:
+      fail-fast: false
       matrix:
-        node-version: [10.x]
+        try-scenario:
+          - ember-lts-3.16
+          - ember-release
+          - ember-beta
+          - ember-canary
+          - ember-classic
+          - ember-default-with-jquery
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm i -g npm@7
-    - run: npm ci
-    - run: node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO
-      env:
-        CI: true
-        EMBER_TRY_SCENARIO: ember-lts-3.16
-
-  ember_try_release:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [10.x]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm i -g npm@7
-    - run: npm ci
-    - run: node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO
-      env:
-        CI: true
-        EMBER_TRY_SCENARIO: ember-release
-
-  ember_try_beta:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [10.x]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm i -g npm@7
-    - run: npm ci
-    - run: node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO
-      env:
-        CI: true
-        EMBER_TRY_SCENARIO: ember-beta
-
-  ember_try_canary:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [10.x]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm i -g npm@7
-    - run: npm ci
-    - run: node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO
-      env:
-        CI: true
-        EMBER_TRY_SCENARIO: ember-canary
-
-  ember_try_default_with_jquery:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [10.x]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm i -g npm@7
-    - run: npm ci
-    - run: node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO
-      env:
-        CI: true
-        EMBER_TRY_SCENARIO: ember-default-with-jquery
-
-  ember_try_classic:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [10.x]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm i -g npm@7
-    - run: npm ci
-    - run: node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO
-      env:
-        CI: true
-        EMBER_TRY_SCENARIO: ember-classic
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 10.x
+          cache: npm
+      - run: npm i -g npm@7
+      - run: npm ci
+      - name: Run Tests
+        run: ./node_modules/.bin/ember try:one ${{ matrix.try-scenario }}


### PR DESCRIPTION
This uses the github ci blueprint from Ember 4.0 as a template


I've also extracted this commit from #117 because it will run Percy without changing any of the code